### PR TITLE
feat(*): use alpine:3.2 for image base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:3.2
+
+ENV DOCKER_REGISTRY_TAG=v2.2.0 \
+    DOCKER_REGISTRY_REPO=https://github.com/docker/distribution.git
+
+# install registry binaries
+RUN export DISTRIBUTION_DIR=/go/src/github.com/docker/distribution \
+    && apk add --update-cache git go make \
+    && git clone -b $DOCKER_REGISTRY_TAG --single-branch $DOCKER_REGISTRY_REPO $DISTRIBUTION_DIR \
+    && cd $DISTRIBUTION_DIR \
+    && export GOPATH=/go:$DISTRIBUTION_DIR/Godeps/_workspace \
+    && make binaries \
+    && cp bin/* /bin/ \
+    && rm -rf /go \
+    && apk del --purge git go make \
+    && rm -rf /var/cache/apk/*
+
+COPY rootfs/ /
+
+# define the execution environment
+VOLUME ["/var/lib/registry"]
+EXPOSE 5000
+ENTRYPOINT ["/bin/registry"]
+CMD ["/etc/docker/registry/config.yml"]

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build:
 # For cases where we're building from local
 # We also alter the RC file to set the image name.
 docker-build: check-docker
-	docker build --rm -t ${IMAGE} rootfs
+	docker build --rm -t ${IMAGE} .
 
 # Push to a registry that Kubernetes can access.
 docker-push: check-docker check-registry

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,1 +1,0 @@
-FROM registry:2

--- a/rootfs/etc/docker/registry/config.yml
+++ b/rootfs/etc/docker/registry/config.yml
@@ -1,0 +1,18 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+    cache:
+        blobdescriptor: inmemory
+    filesystem:
+        rootdirectory: /var/lib/registry
+http:
+    addr: :5000
+    headers:
+        X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3


### PR DESCRIPTION
This reuses some of the proposed changes in deis/deis#4641. Advantages:
- allows Deis to control the registry version explicitly
- allows building registry from a different code repo or fork, which may be necessary if S3 compatibility changes are still outstanding
- makes the config.yml file explicit so it's easier to modify
- is fully compatible with `registry:2` and can be configured by environment variables similarly
- is much smaller

``` console
$ docker images | grep registry
192.168.99.100:5000/deis/registry      git-f4c2e91  7e200fa98286   8 minutes ago  32.86 MB
registry                               2            dfb4481bd21b   3 weeks ago    223.5 MB
```
