### PR TITLE
fix(deploy.sh): add trailing slash to quay.io/

### DIFF
--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -7,6 +7,6 @@ cd "$(dirname "$0")" || exit 1
 
 export IMAGE_PREFIX=deisci VERSION=v2-beta
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-DEIS_REGISTRY=''  make -C .. docker-build docker-push
+DEIS_REGISTRY='' make -C .. docker-build docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
-DEIS_REGISTRY=quay.io make -C .. docker-build docker-push
+DEIS_REGISTRY=quay.io/ make -C .. docker-build docker-push


### PR DESCRIPTION
The registry deploy script is broken in Travis CI otherwise.
