### PR TITLE
ref(Makefile): use go 1.6.2 and compress with upx directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DEV_ENV_IMAGE := quay.io/deis/go-dev:0.11.1
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}
-LDFLAGS := "-s -X main.version=${VERSION}"
+LDFLAGS := "-s -w -X main.version=${VERSION}"
 BINDIR := ./rootfs/opt/registry/sbin
 
 # Legacy support for DEV_REGISTRY, plus new support for DEIS_REGISTRY.
@@ -50,7 +50,7 @@ docker-push: check-docker
 build-binary:
 	${DEV_ENV_PREFIX} -e CGO_ENABLED=0 ${DEV_ENV_IMAGE} go build -a -installsuffix cgo -ldflags ${LDFLAGS} -o $(BINDIR)/${SHORT_NAME} main.go
 	$(call check-static-binary,$(BINDIR)/${SHORT_NAME})
-	${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE} goupx --strip-binary -9 --brute $(BINDIR)/${SHORT_NAME}
+	${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE} upx -9 --brute $(BINDIR)/${SHORT_NAME}
 
 # Deploy is a Kubernetes-oriented target
 deploy: kube-secret kube-service kube-rc

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REPO_PATH = github.com/deis/registry
 
 # The following variables describe the containerized development environment
 # and other build options
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.10.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.11.1
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}


### PR DESCRIPTION
The `goupx` tool isn't needed since go 1.6 [according to its author](https://github.com/pwaller/goupx/blob/master/README.md#update-20160310).

See also https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/ for a general discussion of the binary compression strategy Workflow components are using.
