### PR TITLE
fix(Makefile): remove includes.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docker-build: check-docker build
 	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}
 
 # Push to a registry that Kubernetes can access.
-docker-push: check-docker check-registry
+docker-push: check-docker
 	docker push ${IMAGE}
 
 build-binary:

--- a/includes.mk
+++ b/includes.mk
@@ -9,9 +9,3 @@ check-kubectl:
 		echo "Missing \`kubectl\` client which is required for development"; \
 		exit 2; \
 	fi
-
-check-registry:
-	@if [ -z "$$DEIS_REGISTRY" ] && [ -z "$$DEV_REGISTRY" ]; then \
-		echo "DEIS_REGISTRY is not exported"; \
-		exit 2; \
-	fi


### PR DESCRIPTION
this has since been removed in other projects, so this brings the registry in line with the rest of the crew. Also fixes an issue we're seeing in CI deploying the registry to quay/dockerhub
