### PR TITLE
ref(Makefile): remove obsolete "docker tag -f" flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build: check-docker
 # We also alter the RC file to set the image name.
 docker-build: check-docker build
 	docker build --rm -t ${IMAGE} rootfs
-	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}
+	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 # Push to a registry that Kubernetes can access.
 docker-push: check-docker


### PR DESCRIPTION
This is an error with Docker 1.12.
