### PR TITLE
ref(Dockerfile): remove WORKFLOW_RELEASE envvar

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -27,5 +27,3 @@ RUN apt-get update \
 VOLUME ["/var/lib/registry"]
 CMD ["/opt/registry/sbin/registry"]
 EXPOSE 5000
-
-ENV WORKFLOW_RELEASE 2.0.0


### PR DESCRIPTION
This is no longer necessary.

refs deis/workflow#356
