### PR TITLE
fix(create_bucket): avoid S3 InvalidLocationConstraint error

### DIFF
--- a/rootfs/bin/create-bucket
+++ b/rootfs/bin/create-bucket
@@ -25,7 +25,11 @@ if os.getenv('REGISTRY_STORAGE') == "s3" and os.getenv('REGISTRY_STORAGE_S3_BACK
     conn = boto.s3.connect_to_region(region)
 
     if not bucket_exists(conn, bucket_name):
-        conn.create_bucket(bucket_name, location=region)
+        if region == "us-east-1":
+            # use "US Standard" region. workaround for https://github.com/boto/boto3/issues/125
+            conn.create_bucket(bucket_name)
+        else:
+            conn.create_bucket(bucket_name, location=region)
 
 elif os.getenv('REGISTRY_STORAGE') == "gcs":
     scopes = ['https://www.googleapis.com/auth/devstorage.full_control']


### PR DESCRIPTION
calling create_bucket(bucket_name, region="us-east-1") yields the
following error:

```
boto.exception.S3ResponseError: S3ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidLocationConstraint</Code>
<Message>The specified location-constraint is not valid</Message>
<LocationConstraint>us-east-1</LocationConstraint>...</Error>
```

based on the comments in boto/boto3#125 this commit omits the region
kwarg to the create_bucket() call when `s3.region` is set to "us-east-1"