### PR TITLE
fix(.travis.yml): declare env vars on one line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ services:
   - docker
 env:
   # HACK(bacongobbler): make travis tests work
-  - DEIS_REGISTRY=travis-ci
-  - DOCKER_BUILD_FLAGS="--pull --no-cache"
+  - DEIS_REGISTRY=travis-ci DOCKER_BUILD_FLAGS="--pull --no-cache"
 install:
   - make docker-build
 script:


### PR DESCRIPTION
Without this change, Travis CI runs a separate [job for each environment variable](https://docs.travis-ci.com/user/environment-variables/#Defining-Multiple-Variables-per-Item), which was unintended.