### PR TITLE
chore(Dockerfile): bump registry to v2.6.0

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:2.5.1
+FROM registry:2.6.0
 
 RUN apk add --no-cache \
         python3 && \


### PR DESCRIPTION
This image was released in January and hasn't had any major issues as far as I can tell.

See https://github.com/docker/distribution/releases/tag/v2.6.0 for more info.