### PR TITLE
fix(charts): Set sessionAffinity in registry service

### DIFF
--- a/charts/registry/templates/registry-service.yaml
+++ b/charts/registry/templates/registry-service.yaml
@@ -12,4 +12,5 @@ spec:
       targetPort: 5000
   selector:
     app: deis-registry
+  sessionAffinity: ClientIP  
 {{- end }}


### PR DESCRIPTION
Sets the sessionAffinity on the deis-registry service to fix pushes when multiple registry replicas are deployed.

Fixes #84